### PR TITLE
added option to disable showing the numbers

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -237,6 +237,7 @@ export interface StepperProps {
   verticalLabels?: boolean; // Allow Step header text labels to be placed at the bottom or to the right of the circles, default = true
   hideLabels?: boolean; // Allow to hide the text labels, default = false
   hideLines?: boolean; // Allow to hide the line between each step header circles, default = false
+  hideNumbers?: boolean; // Allow to hide the number inside of the step circle, default = false
   mode?: 'vertical' | 'horizontal'; // Allow to display the stepper 'vertical' or 'horizontal', default = 'horizontal'
 }
 export interface StepperRef {

--- a/src/Stepper.tsx
+++ b/src/Stepper.tsx
@@ -20,6 +20,7 @@ export interface StepperProps {
   verticalLabels?: boolean;
   hideLabels?: boolean;
   hideLines?: boolean;
+  hideNumbers?: boolean;
   mode?: 'vertical' | 'horizontal';
 }
 export interface StepperRef {
@@ -38,6 +39,7 @@ export const Stepper = React.memo(
       verticalLabels = true,
       hideLabels = false,
       hideLines = false,
+      hideNumbers = false,
       mode = 'horizontal',
       headerStyles = {
         color: '#fff',
@@ -140,6 +142,7 @@ export const Stepper = React.memo(
           verticalLabels={verticalLabels}
           hideLabels={hideLabels}
           hideLines={hideLines}
+          hideNumbers={hideNumbers}
           mode={mode}
         />
 
@@ -214,6 +217,7 @@ export interface HeaderSteps {
   verticalLabels?: boolean;
   hideLabels?: boolean;
   hideLines?: boolean;
+  hideNumbers?: boolean;
   mode?: 'vertical' | 'horizontal';
 }
 
@@ -238,6 +242,7 @@ export const HeaderStep = React.memo(function ({
   verticalLabels = false,
   hideLines = false,
   hideLabels = false,
+  hideNumbers = false,
   mode = 'horizontal'
 }: HeaderSteps): JSX.Element {
   const headerEl = labels.map((label, index) => (
@@ -263,7 +268,7 @@ export const HeaderStep = React.memo(function ({
                 : headerStyles.stepsBackgroud
           }}
         >
-          {index + 1}
+          {hideNumbers ? '' : index + 1}
         </div>
         {label.label && !hideLabels && (
           <span


### PR DESCRIPTION
Added an option that can be passed in to disable showing the numbers inside the circle, as well as the documentation. I had a need to do this for what I'm using this stepper for, and thought other devs might have a need for it as well.